### PR TITLE
fix: Cannot read property 'Symbol(TIMER::READ_TIMER)' of null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ exports.request = function (url, opts) {
     var rejected = (err) => {
       err.message += `${method} ${format(parsed)} failed.`;
       // clear response timer when error
-      if (request.socket[READ_TIMER]) {
+      if (request.socket && request.socket[READ_TIMER]) {
         clearTimeout(request.socket[READ_TIMER]);
       }
       reject(err);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "coveralls": "^2.11.15",
     "eslint": "^6.6.0",
     "mocha": "^4",
-    "nyc": "^12.0.2"
+    "nyc": "^12.0.2",
+    "socks-proxy-agent": "^5.0.0"
   },
   "dependencies": {
     "@types/node": "^12.0.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,6 +3,7 @@
 const http = require('http');
 const zlib = require('zlib');
 const assert = require('assert');
+const SocksProxyAgent = require('socks-proxy-agent');
 
 const httpx = require('../');
 
@@ -115,5 +116,16 @@ describe('httpx', () => {
     });
     assert.ok(err, 'should throw error');
     assert.equal(err.message, 'ReadTimeout: 100. GET /readTimeout2 failed.');
+  });
+
+  it('should throw an error', async function () {
+    try {
+      // socks://127.0.0.1:3000 is an invalid socks proxy address.
+      await make(server)('/', { agent: new SocksProxyAgent('socks://127.0.0.1:3000') });
+      assert.fail('should not run here');
+    } catch (error) {
+      const port = server.address().port;
+      assert.equal(error.message, `connect ECONNREFUSED 127.0.0.1:3000GET http://127.0.0.1:${port}/ failed.`);
+    }
   });
 });


### PR DESCRIPTION
当使用 SocksProxyAgent 做代理的时候，如果 `new SocksProxyAgent('socks://127.0.0.1:3000')` 中的 address 无法访问，则 httpx 内部会抛错，并且这个错误无法被正常捕获。

```sh
$ npm run test

> httpx@2.2.3 test /Users/jh/inbox/github/httpx
> mocha --reporter spec --timeout 3000 test/*.test.js



  httpx
(node:14882) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'Symbol(TIMER::READ_TIMER)' of null
    at ClientRequest.rejected (/Users/jh/inbox/github/httpx/lib/index.js:98:25)
    at ClientRequest.emit (events.js:196:13)
    at onerror (/Users/jh/inbox/github/httpx/node_modules/agent-base/dist/src/index.js:114:21)
    at callbackError (/Users/jh/inbox/github/httpx/node_modules/agent-base/dist/src/index.js:133:17)
    at processTicksAndRejections (internal/process/task_queues.js:89:5)
(node:14882) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:14882) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```



```js
  it.only('should throw an error', async function () {
    try {
      // socks://127.0.0.1:3000 is an invalid socks proxy address.
      await make(server)('/', { agent: new SocksProxyAgent('socks://127.0.0.1:3000') });
      assert.fail('should not run here');
    } catch (error) {
      const port = server.address().port;
      assert.equal(error.message, `connect ECONNREFUSED 127.0.0.1:3000GET http://127.0.0.1:${port}/ failed.`);
    }
  });
```